### PR TITLE
Support RN 0.68 Obj-C++ AppDelegate

### DIFF
--- a/plugin/src/ios/appDelegate.ts
+++ b/plugin/src/ios/appDelegate.ts
@@ -42,7 +42,7 @@ export const withAppCenterAppDelegate: ConfigPlugin = (config) => {
         config.modRequest.projectRoot
       );
       let contents = await fs.readFile(fileInfo.path, "utf-8");
-      if (fileInfo.language === "objc") {
+      if (fileInfo.language === "objc" || fileInfo.language === "objcpp") {
         contents = modifyObjcAppDelegate(contents);
       } else {
         // TODO: Support Swift


### PR DESCRIPTION
Added objcpp check for appdelegate

Reason: New release of RN 0.68 uses AppDelegate.mm instead of AppDelegate.m